### PR TITLE
remove "armv8", replace with "arm64"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Works on Arm Cluster
 
-The [Works on Arm cluster](https://www.worksonarm.com/cluster) provides free access to state-of-the-art computing resources for open source developers working to port, test, and build their software on Armv8 servers. We currently offer access to Armv8 bare metal servers from several supporting manufacturers for software builds, continuous integration, scale testing, and demonstrations. 
+The [Works on Arm cluster](https://www.worksonarm.com/cluster) provides free access to state-of-the-art computing resources for open source developers working to port, test, and build their software on Armv8 servers. We currently offer access to arm64 (aarch64) bare metal servers from several supporting manufacturers for software builds, continuous integration, scale testing, and demonstrations. 
 
-The on-demand infrastructure resource is managed by New York City-based [Packet](https://www.packet.net/), a leading bare metal cloud, as part of its commitment to the Arm communities. Funding for the system is provided by Arm Holdings. The resources are primarily located in Packet's EWR1 (New York City area) data center. It allows developers extended testing or the ability to build out continuous integrated infrastructure with the automation and consistency of big public clouds without being required to use virtualization.
+The on-demand infrastructure resource is managed by New York City-based [Packet](https://www.packet.net/), a leading bare metal cloud, as part of its commitment to the Arm communities. Funding for the system is provided by Arm Holdings. The resources are primarily located in Packet's EWR1 (New York City area) data center. The cluster provides developers resources for extended testing and the ability to build out continuous integrated infrastructure with the automation and consistency of big public clouds without being required to use virtualization.
 
 Apply to Use the On-Demand Infrastructure by [creating an issue](https://github.com/WorksOnArm/cluster/issues/new) in this repository. Contact ed@packet.net (Ed Vielmetti, Works on Arm program manager) for any questions.
 


### PR DESCRIPTION
reflect the common use in the community of "arm64" to represent the platform. Closes #64 