### PR TITLE
CI.md - continuous integration on arm64

### DIFF
--- a/CI.md
+++ b/CI.md
@@ -27,6 +27,9 @@ Github is a source code management system with integrations into many
 CI systems. Projects managed on Github can interface with CI through
 use of webhooks to trigger build events.
 
+* http://www.gihtub.com
+* https://github.com/marketplace/category/continuous-integration
+
 ### Gitlab
 
 ### Jenkins

--- a/CI.md
+++ b/CI.md
@@ -11,6 +11,8 @@ is out of date.
 
 ### bazel
 
+Bazel is a build system derived from Google's internal "Blaze" system.
+
 ### buildbot
 
 ### CircleCI
@@ -19,12 +21,20 @@ is out of date.
 
 ### Codefresh
 
+### Github
+
+Github is a source code management system with integrations into many
+CI systems. Projects managed on Github can interface with CI through
+use of webhooks to trigger build events.
+
 ### Gitlab
 
 ### Jenkins
 
 ### Shippable
 
-### TravisCI
+### Travis CI
 
 ### VSTS
+
+VSTS is Visual Studio Team Services, a Microsoft product.

--- a/CI.md
+++ b/CI.md
@@ -1,0 +1,20 @@
+# Continuous Integration (CI) on arm64 at Packet
+
+This handy guide lists a set of CI and build systems that have been known to work
+on arm64, with examples of projects that are successfully using them.
+In addition, it notes some issues that are outstanding on some build systems
+and efforts to address them.
+
+If you are changing this file, please date stamp your changes. 
+You can safely assume that any report more than 6 months old
+is out of date.
+
+### bazel
+
+### buildbot
+
+### CMake
+
+### Gitlab
+
+### Jenkins

--- a/CI.md
+++ b/CI.md
@@ -17,9 +17,13 @@ is out of date.
 
 ### CMake
 
+### Codefresh
+
 ### Gitlab
 
 ### Jenkins
+
+### Shippable
 
 ### TravisCI
 

--- a/CI.md
+++ b/CI.md
@@ -9,17 +9,27 @@ If you are changing this file, please date stamp your changes.
 You can safely assume that any report more than 6 months old
 is out of date.
 
+Ed Vielmetti, Works on Arm, 2018-08-06
+
 ### bazel
 
-Bazel is a build system derived from Google's internal "Blaze" system.
+[Bazel](https://bazel.build/) is a build system derived from Google's internal "Blaze" system.
 
 ### buildbot
 
+[Buildbot](https://buildbot.net/) is a continuous integration framework.
+
 ### CircleCI
+
+[CircleCI](https://circleci.com/) is a a modern continuous integration and continuous delivery (CI/CD) platform.
 
 ### CMake
 
+[CMake](https://cmake.org/) is an open-source, cross-platform family of tools designed to build, test and package software.
+
 ### Codefresh
+
+[Codefresh](https://codefresh.io/) is a continuous delivery platform built for Kubernetes.
 
 ### Github
 

--- a/CI.md
+++ b/CI.md
@@ -13,8 +13,14 @@ is out of date.
 
 ### buildbot
 
+### CircleCI
+
 ### CMake
 
 ### Gitlab
 
 ### Jenkins
+
+### TravisCI
+
+### VSTS


### PR DESCRIPTION
Closes #72, "Document the way various people are doing CI".

This starts as a skeleton with an intro and a very partial list, with
a goal of being a complete guide to all known CI systems that
run on arm64 or that are being developed for arm64.

Assume that any entry over 6 months old is out of date, and
structure the file so that a report can flag that it contains old
content. That might just be a regex matching 2018-06 run in 2018-12.